### PR TITLE
Compatibility with VAB Organizer

### DIFF
--- a/GameData/SquiggsySpaceResearch/Patches/VABO.cfg
+++ b/GameData/SquiggsySpaceResearch/Patches/VABO.cfg
@@ -1,0 +1,158 @@
+// Config for MicroSat Parts
+
+/// Cargo
+/// -------------
+
+/// Command
+/// -------------
+@PART[MicroSat]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = probes
+  }
+}
+
+/// Communication
+/// -------------
+@PART[FixedDish01]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = relay
+  }
+}
+@PART[foldedDipole|foldingDish01]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = direct
+  }
+}
+
+/// Control
+/// -------------
+
+/// Coupling
+/// -------------
+@PART[35decoupler|625decoupler]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = decouplers
+  }
+}
+
+/// Electrical
+/// -------------
+@PART[MICROBATSQUARE]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = batteries
+  }
+}
+//@PART[microCapacitor]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer&NearFutureElectrical]
+//{
+//  %VABORGANIZER
+//  {
+//    %organizerSubcategory = capacitors
+//  }
+//}
+@PART[micrortg]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = rtgs
+  }
+}
+@PART[microSolarUnshielded]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = solarPanels
+  }
+}
+
+/// Fuel
+/// -------------
+@PART[625liquidFuel|microlqdfuel]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = lfo
+  }
+}
+@PART[microXenon|radialXenonmicro]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = xenon
+  }
+}
+@PART[microArgon]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer&NearFuturePropulsion]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = argon
+  }
+}
+
+/// Engines
+/// -------------
+@PART[upperStageEngine|microsatEngine]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = lfoEngines
+  }
+}
+@PART[solidBoosterMini]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = solidEngines
+  }
+}
+@PART[microIon]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = ionEngines
+  }
+}
+
+/// Ground
+/// -------------
+
+/// Payload
+/// -------------
+@PART[fairingSize0]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = fairings
+  }
+}
+
+/// Robotics
+/// -------------
+
+/// Science
+/// -------------
+@PART[MicroScanner]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = resourceScanners
+  }
+}
+
+/// Structural
+/// -------------
+
+/// Thermal
+/// -------------
+
+/// Utility
+/// -------------

--- a/GameData/SquiggsySpaceResearch/Patches/VABO.cfg
+++ b/GameData/SquiggsySpaceResearch/Patches/VABO.cfg
@@ -1,5 +1,8 @@
 // Config for MicroSat Parts
 
+/// Aero
+///--------------
+
 /// Cargo
 /// -------------
 
@@ -52,13 +55,13 @@
     %organizerSubcategory = batteries
   }
 }
-//@PART[microCapacitor]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer&NearFutureElectrical]
-//{
-//  %VABORGANIZER
-//  {
-//    %organizerSubcategory = capacitors
-//  }
-//}
+@PART[microCapacitor]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer&NearFutureElectrical]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = capacitors
+  }
+}
 @PART[micrortg]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
 {
   %VABORGANIZER
@@ -71,30 +74,6 @@
   %VABORGANIZER
   {
     %organizerSubcategory = solarPanels
-  }
-}
-
-/// Fuel
-/// -------------
-@PART[625liquidFuel|microlqdfuel]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
-{
-  %VABORGANIZER
-  {
-    %organizerSubcategory = lfo
-  }
-}
-@PART[microXenon|radialXenonmicro]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
-{
-  %VABORGANIZER
-  {
-    %organizerSubcategory = xenon
-  }
-}
-@PART[microArgon]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer&NearFuturePropulsion]
-{
-  %VABORGANIZER
-  {
-    %organizerSubcategory = argon
   }
 }
 
@@ -119,6 +98,30 @@
   %VABORGANIZER
   {
     %organizerSubcategory = ionEngines
+  }
+}
+
+/// Fuel
+/// -------------
+@PART[625liquidFuel|microlqdfuel]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = lfo
+  }
+}
+@PART[microXenon|radialXenonmicro]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = xenon
+  }
+}
+@PART[microArgon]:FOR[SquiggsySpaceResearch]:NEEDS[VABOrganizer&NearFuturePropulsion]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = argon
   }
 }
 


### PR DESCRIPTION
Added compatibility for [VAB Organizer](https://github.com/post-kerbin-mining-corporation/VABOrganizer) within the [0.35m SSR MicroSat and Airlaunch Vehicle](https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts) mod.

~~Currently, awaiting an update to [Near Future Electrical](https://github.com/post-kerbin-mining-corporation/NearFutureElectrical) to see how capacitors are handled in VAB Organizer. This file, currently, has a commented-out section on how I anticipate it to be added, but will await further until certain.~~

[Dev branch](https://github.com/post-kerbin-mining-corporation/NearFutureElectrical/tree/dev) of [Near Future Electrical](https://github.com/post-kerbin-mining-corporation/NearFutureElectrical) includes the subcategory used. Awaiting release to submit a pull request to upstream.